### PR TITLE
fix frameset role XML closing tag

### DIFF
--- a/frames/fork.xml
+++ b/frames/fork.xml
@@ -77,10 +77,11 @@
           </rolelinks>
         </role>
         <role descr="person paid" f="GOL" n="2"/>
-        <role descr="price" f="VSP" n="3"/>
+        <role descr="price" f="VSP" n="3">
           <rolelinks>
             <rolelink class="pocket-9.10" resource="VerbNet" version="verbnet3.4">theme</rolelink>
           </rolelinks>
+        </role>
       </roles>
       <usagenotes>
         <usage resource="PropBank" version="1.0" inuse="-"/>


### PR DESCRIPTION
This fixes a child `rolelinks` element under `role` in `fork.xml` that was prematurely closed.  